### PR TITLE
Write timestamp of last scraper run and adjust CRON scheduling

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -2,7 +2,7 @@ name: Web Scrape
 
 on:
   schedule:
-    - cron: "0 5 * * *" # runs at 00:00 or 01:00 EST (06:00 UTC) every day, depending on daylight savings
+    - cron: "0 3 * * *" # runs at 10:00 or 11:00 EST (03:00 UTC) every day, depending on daylight savings
 
 jobs:
   scrape-latest:

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -2,7 +2,7 @@ name: Web Scrape
 
 on:
   schedule:
-    - cron: "0 3 * * *" # runs at 10:00 or 11:00 EST (03:00 UTC) every day, depending on daylight savings
+    - cron: "30 3 * * *" # runs at 10:00 or 11:00 EST (03:00 UTC) every day, depending on daylight savings
 
 jobs:
   scrape-latest:

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 from bs4 import BeautifulSoup
 import requests
+from datetime import datetime
 
 def main():
     scrape()
@@ -74,6 +75,13 @@ def scrape():
                 # Write calendar links (which all, hopefully, have the word "calendar" in their title at some point)
                 if "calendar" in calendar_title.lower():
                     f.write(f"- {calendar_title}: {calendar_url}\n") # Use a string literal for users to more easily identify what calendar each link leads to
+
+            # Retrieve and write (current) timestamp of the last scraper and URL check run
+            timestamp = datetime.now()
+            day = timestamp.strftime("%a %b. %d, %Y")
+            time = timestamp.strftime("%H:%M")
+            f.write("\n") # Write a newline before timestamp
+            f.write(f"Last updated on {day} at {time}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- Updates `main.py` to write formatted timestamp of last scraper run/update
- Adjusts CRON schedule for self-updating workflow: later time in the hour and different hour

Fixes #1 