### PR TITLE
Improvements and add admissions articles scraper

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -1,12 +1,12 @@
 # About `mari-updates`
 
-Thanks for visiting my `mari-updates` repo! If you're wondering how it works and why it was created, you're in the right place. If you'd like to run or test the web scraper on your local machine, skip to [Running the scraper locally](#running-the-scraper-locally).
+Thanks for visiting my `mari-updates` repo! If you're wondering how it works, you're in the right place. If you'd like to run or test the web scraper on your local machine, skip to [Running the scraper locally](#running-the-scraper-locally).
 
 *To see the self-updating README with the scraped updates, please go to [README.md](README.md).*
 
 ## Web scraper
 
-The most central "piece" of code in this repo is the web scraper component — this is written in Python and uses the Beautiful Soup and `requests` libraries to scrape content from two sites. The Python script that does all this is `main.py` — there are also comments alongside the code that explain the role of certain lines and parts of the code, so do take a look at the file to see exactly how everything was programmed.
+The most central "piece" of code in this repo is the web scraper component — this is written in Python and uses the Beautiful Soup and `requests` libraries to scrape content from two sites. The Python script that does all this is `main.py` — there are also comments alongside the code that explain the role of certain lines and parts of the code, so do take a look at the file to see exactly how everything was programmed. *(See [Self-updating workflow](#self-updating-workflow) to see how the script executes through automation.)*
 
 The `scrape()` function contains the code that scrapes the sites, and does the following:
 
@@ -14,16 +14,18 @@ The `scrape()` function contains the code that scrapes the sites, and does the f
 - If the request(s) result(s) in `200 OK` HTTP codes, the script fetches the text content of the specified URL (link)
   - `requests.get(<url>).status_code` returns the HTTP status code returned by a `GET` request
   - *A "fallback" was implemented in case the resulting HTTP code is **not** the expected `200`. See [Troubleshooting](#troubleshooting) for more information.*
-- The BeautifulSoup library is used to parse the text content as LXML:
-  - For the admissions updates section of the scraper, the program searches for the `<div>` with the classes `x-section e4336-11 m3cg-0 m3cg-3 m3cg-4`, which contains all updates posted by the admissions teams (and that's what we want!)
-  - For the calendar links section, the program searches inside an `<article>` tag (where the calendar links tend to be included) for links, or anchor tags `<a>`, containing the word "calendar" (case-insensitive)
+
+Within this same function (`scrape()`), the BeautifulSoup library is used to parse the text content as LXML:
+
+- ***For the admissions updates section of the scraper***, the program searches for the `<div>` with the classes `x-section e4336-11 m3cg-0 m3cg-3 m3cg-4`, which contains all updates posted by the admissions teams (and that's what we want!). A condition checks whether a `<strong>` tag was found within the `<p>` tags scraped, the latter of which contain both update titles and the actual updates themselves; if `strong` (bold) formatting is "detected", then the text of that paragraph is written with bold formatting, otherwise it'll be written as normal text.
+- ***For the calendar links section***, the program searches inside an `<article>` tag (where the calendar links tend to be included) for links, or anchor tags `<a>`, containing the word "calendar" (case-insensitive)
+- ***For Marianopolis' admissions articles section***, each article is found in an `<article>` tag. The title is found in an `<h2>` tag with a class of `entry-title`, the publication date in the text content of `<time>` tags, and so on *(see `main.py` for the rest, or visit the admissions articles page of Marianopolis' website to inspect the code for yourself)*. Each article entry is then added as a row to a Markdown table with three columns, "Article", "Publish Date" and "Excerpt". The article titles also link to their corresponding articles.
 - The desired site content scraped from above is then written to `README.md` every time the scraper script is run
-  - The `datetime` and `pytz` Python modules are used to retrieve and update the time of the latest scraper/workflow run, written at the very end of `README.md`. `datetime` retrieves the current time, then the `timezone` function from `pytz` converts it to Eastern Standard Time, and finally the `strftime` function formats the timestamp as *"Last updated on {weekday} {month}. {day}, {year} at {time AM/PM} (EST)"* — you'll find this timestamp the bottom of the [README](README.md).
-  - **See [Self-updating workflow](#self-updating-workflow) to see how the script executes through automation).**
+- The `datetime` and `pytz` Python modules are used to retrieve and update the time of the latest scraper/workflow run, written at the very end of `README.md`. `datetime` retrieves the current time, then the `timezone` function from `pytz` converts it to Eastern Standard Time, and finally the `strftime` function formats the timestamp as *"Last updated on {weekday} {month}. {day}, {year} at {time AM/PM} (EST)"* — you'll find this timestamp the bottom of the [README](README.md).
 
 ### Self-updating workflow
 
-This part of the repo is just as important, because it's an Actions workflow that's automating the process of running the scraper program, and thus updating the README once a day. *("Actions workflow" is referring to a [GitHub Actions workflow](https://docs.github.com/en/actions). It's an incredibly useful and powerful feature of GitHub that can help programmers automate, test, and deploy programs right from their repositories.)*
+This part of the repo is just as important, because it's an Actions workflow that's automating the process of running the scraper program, and thus updating the README once a day. *("Actions workflow" refers to a [GitHub Actions workflow](https://docs.github.com/en/actions). It's an incredibly useful and powerful feature of GitHub that can help programmers automate, test, and deploy programs right from their repositories.)*
 
 The workflow responsible for running the scraper is named "Web Scrape", and can be found in the `scrape.yml` file of this repo (the file path is `.github/workflows/scrape.yml`). It uses several Actions and steps:
 
@@ -33,13 +35,13 @@ The workflow responsible for running the scraper is named "Web Scrape", and can 
 - The "Execute scraper script" step: run/interpret the `main.py` Python web scraping script
 - The [Add & Commit](https://github.com/EndBug/add-and-commit) action (*"Commit updates (scrape results)"*): commit changes made in previous steps of this workflow directly to the repo, sets me as the commit author and GitHub Actions as the committer
 
-The entire workflow runs on a `schedule` thanks to this `cron` syntax: `"30 3 * * *"`. This causes the workflow to run at 03:30 AM (UTC) every day, thereby scraping the sites and updating the README accordingly.
+The entire workflow runs on a `schedule` thanks to this `cron` syntax: `"30 3,15 * * *"`. This causes the workflow to run at 03:30 AM and PM (UTC) every day, thereby scraping the sites and updating the README accordingly.
 
 ### Troubleshooting
 
 A fallback option was implemented in case any errors arose with making a request to either of the websites, or with parsing the code/text. 
 
-While testing the scraper program locally, an error was discovered where the program is unable to parse code or write text to the README if certain unicode characters like the no-breaking space (`U+00A0`) are present. The solution was to normalize the text using the built-in `unicodedata` Python module, which in turn removes any problematic unicode characters to prevent such errors.
+While testing the scraper program locally, an error was discovered where the program is unable to parse code or write text to the README if certain unicode characters like the no-breaking space (`U+00A0`) are present. The solution was to normalize the text using the built-in `unicodedata` Python module, which in turn removes any problematic unicode characters to prevent such errors — this is now completed through a `normalize()` function. At one point, smart quotes were being "normalized" to the *specials* unicode block (�), so they were replaced with non-typographic quotes (`'`) using a separate `.replace()` method.
 
 An important issue is that websites tend to evolve and change, including URL paths, so it's best if web scrapers have fallbacks in preparation to handle these situations. This is where the `checkurl()` function comes in: if it discovers that the HTTP status code returned by a `request` isn't `200 OK`, it'll write the problematic URL to the `ERRORS.md` file and return `1`. In the `scrape()` function, if `checkurl()` doesn't return a value of `0`, which essentially means "all good" for the links, then it won't write anything to the README. This was done to preserve the last scraped version of the text, even if it may be out-of-date, rather than injecting Python code errors or just failing the entire Actions workflow.
 
@@ -55,4 +57,4 @@ You can also clone this repo, or at the very least `main.py` and `requirements.t
 
 4. To run the scraper, simply type `python main.py` to run the Python script. Results should be written to `README.md` or `ERRORS.md`, depending on the status code(s) returned by the websites.
 
-And that's it!
+And that's it! This was my first web scraper, and thus my first time working with BeautifulSoup — I found it quite fun and definitely learned lots. Thanks for checking out this repository and consider giving it a star 😄

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ def main():
     scrape()
 
 """
-Simple web scraper for Marianopolis College's admissions updates and calendars
+Simple web scraper for Marianopolis College's admissions updates, calendars and events
 Modified from my web scraper built for LHD: Build day 4 (see my lhd_build repo)
 """
 
@@ -56,30 +56,62 @@ def scrape():
     calendars = calendar_section.find_all("a")
 
     """
-    Open README file and write if URL checks for both links pass
+    Scrape admissions articles published in 2022 (title, date published, summary, link to article/event)
+    """
+    # Grab HTML of the corresponding site section
+    url_articles = "https://www.bemarianopolis.ca/category/admissions/"
+    html_articles = requests.get(url_articles).text
+
+    soup = BeautifulSoup(html_articles, "lxml") # Also parse with LXML parser
+
+    # Find all <article> elements, each of which have the link to an article,
+    # The title, publish date, and a preview snippet/excerpt
+    articles = soup.find_all("article", class_ = "type-post")
+
+    """
+    Open README file and write if URL checks for all links pass
     """
     if (check_url(url_adm) == 0) and (check_url(url_cal) == 0):
         with open("README.md", "w") as f:
             # Write introduction and some headings
             f.write("## Marianopolis College updates\n\n")
-            f.write("This runs on a web scraper built with Python and Beautiful Soup, which updates and writes to the README in this repo daily thanks to GitHub Actions automation.\n\n")
+            f.write("This runs on a web scraper built with Python and Beautiful Soup, which updates and writes to the README in this repo twice daily thanks to GitHub Actions automation.\n\n")
             f.write("*Refer to [DOCS.md](DOCS.md) for this repository's documentation.*\n\n")
             f.write("### [Admissions updates](https://www.bemarianopolis.ca/admissions/admissions-updates/)\n\n")
 
             # Write admissions updates
             for update in updates:
-                update_text = unicodedata.normalize("NFKD", update.text)
+                update_text = unicodedata.normalize("NFKD", update.text.replace("\u2019", "'"))
                 f.write(update_text + "\n\n")
 
             f.write("### [Calendars](https://www.marianopolis.edu/campus-life/calendar/)\n\n")
 
             for calendar in calendars:
                 calendar_url = calendar["href"] # Loop through each calendar link (anchor tag) and extract its href attribute (its URL)
-                calendar_title = unicodedata.normalize("NFKD", calendar.text)  # Save the "title" of the calendar
+                calendar_title = unicodedata.normalize("NFKD", calendar.text.replace("\u2019", "'"))  # Save the "title" of the calendar
 
                 # Write calendar links (which all, hopefully, have the word "calendar" in their title at some point)
                 if "calendar" in calendar_title.lower():
                     f.write(f"- {calendar_title}: {calendar_url}\n") # Use a string literal for users to more easily identify what calendar each link leads to
+
+            # Write current year's admissions articles
+            f.write("\n### [Admission articles](https://www.bemarianopolis.ca/category/admissions/)\n\n")
+            # Prepare table (head and separator)
+            f.write("| Article | Publish Date | Excerpt |\n")
+            f.write("| ------- | ------------ | ------- |\n")
+
+            for article in articles:
+                if "2022" in (article.select_one("p.p-meta > span > time.entry-date").text):
+                    article_title = unicodedata.normalize("NFKD", article.find("h2", class_ = "entry-title").text.replace("\u2019", "'").strip("\n")) # Get entry title
+                    article_excerpt = article.find("div", class_ = "entry-content excerpt") # Get excerpt div (contains links and snippets/summaries)
+
+                    article_pubdate = unicodedata.normalize("NFKD", article.select_one("p.p-meta > span > time.entry-date").text.replace("\u2019", "'")) # Get publish date in text form
+                    article_link = article_excerpt.find("a")["href"].strip("\n") # Get article link (scraped from the "Read More" link button in the excerpt divs)
+                    article_snippet = unicodedata.normalize("NFKD", article_excerpt.find("p").text.replace("\u2019", "'")) # Get snippets/summaries of the articles
+
+
+                    # Write article data to table row (Markdown)
+                    f.write(f"| [{article_title}]({article_link}) | {article_pubdate} | {article_snippet} |\n")
 
             # Retrieve and write (current) timestamp of the last scraper and URL check run
             timestamp = datetime.now(timezone('America/Toronto')) # Convert to EST timezone (Toronto is a commonly used standard timezone that matches our purposes)

--- a/main.py
+++ b/main.py
@@ -22,6 +22,13 @@ def check_url(url):
     else:
         return 0
 
+
+def normalize(text):
+    # Replace smart quotes/apostrophes and normalize unicode 
+    # (unicodedata hasn't been replacing smart quotes, so it's being done separately)
+    normalized = unicodedata.normalize("NFKD", text.replace("\u2019", "'"))
+    return normalized
+
 def scrape():
     """
     Scrape admissions updates
@@ -81,14 +88,14 @@ def scrape():
 
             # Write admissions updates
             for update in updates:
-                update_text = unicodedata.normalize("NFKD", update.text.replace("\u2019", "'"))
+                update_text = normalize(update.text)
                 f.write(update_text + "\n\n")
 
             f.write("### [Calendars](https://www.marianopolis.edu/campus-life/calendar/)\n\n")
 
             for calendar in calendars:
                 calendar_url = calendar["href"] # Loop through each calendar link (anchor tag) and extract its href attribute (its URL)
-                calendar_title = unicodedata.normalize("NFKD", calendar.text.replace("\u2019", "'"))  # Save the "title" of the calendar
+                calendar_title = normalize(calendar.text)  # Save the "title" of the calendar
 
                 # Write calendar links (which all, hopefully, have the word "calendar" in their title at some point)
                 if "calendar" in calendar_title.lower():
@@ -102,12 +109,12 @@ def scrape():
 
             for article in articles:
                 if "2022" in (article.select_one("p.p-meta > span > time.entry-date").text):
-                    article_title = unicodedata.normalize("NFKD", article.find("h2", class_ = "entry-title").text.replace("\u2019", "'").strip("\n")) # Get entry title
+                    article_title = normalize(article.find("h2", class_ = "entry-title").text).strip("\n") # Get entry title
                     article_excerpt = article.find("div", class_ = "entry-content excerpt") # Get excerpt div (contains links and snippets/summaries)
 
-                    article_pubdate = unicodedata.normalize("NFKD", article.select_one("p.p-meta > span > time.entry-date").text.replace("\u2019", "'")) # Get publish date in text form
+                    article_pubdate = normalize(article.select_one("p.p-meta > span > time.entry-date").text) # Get publish date in text form
                     article_link = article_excerpt.find("a")["href"].strip("\n") # Get article link (scraped from the "Read More" link button in the excerpt divs)
-                    article_snippet = unicodedata.normalize("NFKD", article_excerpt.find("p").text.replace("\u2019", "'")) # Get snippets/summaries of the articles
+                    article_snippet = normalize(article_excerpt.find("p").text) # Get snippets/summaries of the articles
 
 
                     # Write article data to table row (Markdown)

--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ def scrape():
     update_section = soup.find("div", class_ = "x-section e4336-11 m3cg-0 m3cg-3 m3cg-4")
 
     # Search for paragraphs containing updates
-    updates = update_section.find_all("p")
+    updates = update_section.select("p")
 
     """
     Scrape calendars (links)
@@ -81,17 +81,24 @@ def scrape():
     if (check_url(url_adm) == 0) and (check_url(url_cal) == 0):
         with open("README.md", "w") as f:
             # Write introduction and some headings
-            f.write("## Marianopolis College updates\n\n")
+            f.write("# Marianopolis College updates\n\n")
             f.write("This runs on a web scraper built with Python and Beautiful Soup, which updates and writes to the README in this repo twice daily thanks to GitHub Actions automation.\n\n")
             f.write("*Refer to [DOCS.md](DOCS.md) for this repository's documentation.*\n\n")
-            f.write("### [Admissions updates](https://www.bemarianopolis.ca/admissions/admissions-updates/)\n\n")
+            f.write("## [Admissions updates](https://www.bemarianopolis.ca/admissions/admissions-updates/)\n\n")
 
             # Write admissions updates
             for update in updates:
-                update_text = normalize(update.text)
-                f.write(update_text + "\n\n")
+            
+                # Write with bold formatting if the text is wrapped in <strong> tags (the update "title")
+                if update.find("strong"):
+                    update_text = normalize(update.text)
+                    f.write(f"**{update_text}**\n\n")
+                else:
+                    update_text = normalize(update.text)
+                    f.write(update_text + "\n\n")
 
-            f.write("### [Calendars](https://www.marianopolis.edu/campus-life/calendar/)\n\n")
+            f.write("## [Calendars](https://www.marianopolis.edu/campus-life/calendar/)\n\n")
+            f.write("Looking for Marianopolis' course and academic calendars? See the list below for past and current published calendars:\n\n")
 
             for calendar in calendars:
                 calendar_url = calendar["href"] # Loop through each calendar link (anchor tag) and extract its href attribute (its URL)
@@ -99,10 +106,11 @@ def scrape():
 
                 # Write calendar links (which all, hopefully, have the word "calendar" in their title at some point)
                 if "calendar" in calendar_title.lower():
-                    f.write(f"- {calendar_title}: {calendar_url}\n") # Use a string literal for users to more easily identify what calendar each link leads to
+                    f.write(f"- *{calendar_title}:* {calendar_url}\n") # Use a string literal for users to more easily identify what calendar each link leads to
 
             # Write current year's admissions articles
-            f.write("\n### [Admission articles](https://www.bemarianopolis.ca/category/admissions/)\n\n")
+            f.write("\n## [Admission articles](https://www.bemarianopolis.ca/category/admissions/)\n\n")
+            f.write("Recent articles published by the Marianpolis staff and recruit team. Click on the title(s) to read the full text:\n\n")
             # Prepare table (head and separator)
             f.write("| Article | Publish Date | Excerpt |\n")
             f.write("| ------- | ------------ | ------- |\n")
@@ -124,7 +132,8 @@ def scrape():
             timestamp = datetime.now(timezone('America/Toronto')) # Convert to EST timezone (Toronto is a commonly used standard timezone that matches our purposes)
             day = timestamp.strftime("%a %b. %d, %Y")
             time = timestamp.strftime("%H:%M %p")
-            f.write("\n") # Write a newline before timestamp
+            # Write horizontal rule before timestamp
+            f.write("\n---\n\n")
             f.write(f"*Last updated on {day} at {time} (EST).*")
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ def scrape():
     update_section = soup.find("div", class_ = "x-section e4336-11 m3cg-0 m3cg-3 m3cg-4")
 
     # Search for paragraphs containing updates
-    updates = update_section.select("p")
+    updates = update_section.find_all("p")
 
     """
     Scrape calendars (links)
@@ -123,7 +123,6 @@ def scrape():
                     article_pubdate = normalize(article.select_one("p.p-meta > span > time.entry-date").text) # Get publish date in text form
                     article_link = article_excerpt.find("a")["href"].strip("\n") # Get article link (scraped from the "Read More" link button in the excerpt divs)
                     article_snippet = normalize(article_excerpt.find("p").text) # Get snippets/summaries of the articles
-
 
                     # Write article data to table row (Markdown)
                     f.write(f"| [{article_title}]({article_link}) | {article_pubdate} | {article_snippet} |\n")


### PR DESCRIPTION
Includes various README formatting, code design and style improvements. The most central modification made here is a new "section"/part of the scraper that scrapes Marianopolis' 2022 admissions articles (possibly TODO: create a workflow or use `datetime` to update the year being detected in article publication dates, rather than having to change it manually).